### PR TITLE
Settings profiles can now be renamed in launcher, clilauncher now accepts a string for a setting profile.

### DIFF
--- a/EVEm8.CliLauncher/Launcher.cs
+++ b/EVEm8.CliLauncher/Launcher.cs
@@ -78,7 +78,7 @@ namespace EVEm8.CliLauncher
             {
                 launchArgs += " /triPlatform=dx9";
             }
-            if (options.Settings != 0)
+            if (options.Settings != "")
             {
                 launchArgs += " /settingsprofile=" + options.Settings;
             }

--- a/EVEm8.CliLauncher/Options.cs
+++ b/EVEm8.CliLauncher/Options.cs
@@ -24,9 +24,9 @@ namespace EVEm8.CliLauncher
           HelpText = "Server name (tq, sisi, duality)")]
         public string Server { get; set; }
 
-        [Option("settingsprofile", DefaultValue = 1,
+        [Option("settingsprofile", DefaultValue = "1",
           HelpText = "Settings profile")]
-        public int Settings { get; set; }
+        public string Settings { get; set; }
 
         [Option("dx9", DefaultValue = false,
           HelpText = "Force DirectX 9")]


### PR DESCRIPTION
I renamed all my profiles to match login names and immediately broke the clilauncher.

Updated settings from int to string.
